### PR TITLE
fix brew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ Ensure that you have the required dependencies installed.
 
    > You can use the following package manager:
    >
-   > | Distribution | Repository  | Instructions                          |
-   > | ------------ | ----------- | ------------------------------------- |
-   > | _Any_        | [Linuxbrew] | `brew install banh-canh/ytui/formula` |
-   > | Arch Linux   | [AUR]       | `yay -S ytui-bin`                     |
+   > | Distribution | Repository  | Instructions                       |
+   > | ------------ | ----------- | ---------------------------------- |
+   > | _Any_        | [Linuxbrew] | `brew install banh-canh/ytui/ytui` |
+   > | Arch Linux   | [AUR]       | `yay -S ytui-bin`                  |
 
    </details>
    <details>

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Ensure that you have the required dependencies installed.
 
    > You can use the following package manager:
    >
-   > | Distribution | Repository  | Instructions                              |
-   > | ------------ | ----------- | ----------------------------------------- |
-   > | _Any_        | [Linuxbrew] | `brew install banh-canh/ytui-tap/formula` |
+   > | Distribution | Repository  | Instructions                       |
+   > | ------------ | ----------- | ---------------------------------- |
+   > | _Any_        | [Linuxbrew] | `brew install banh-canh/ytui/ytui` |
 
    </details>
 


### PR DESCRIPTION
<details>
<summary>
This fails as expected:

    $ brew install banh-canh/ytui


</summary>

```
Warning: No available formula with the name "ytui".
==> Searching for similarly named formulae
==> Formulae
spotify-tui

To install spotify-tui, run:
  brew install spotify-tui
```

</details>

<details>
<summary>
This fails:

    $ brew install banh-canh/ytui/formula

</summary>

```
==> Tapping banh-canh/ytui
Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/banh-canh/homebrew-ytui'...
remote: Enumerating objects: 24, done.
remote: Counting objects: 100% (24/24), done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 24 (delta 5), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (24/24), done.
Resolving deltas: 100% (5/5), done.
Tapped 1 formula (13 files, 72.7KB).
Warning: No available formula with the name "banh-canh/ytui/formula". Did you mean banh-canh/ytui/ytui?
```

</details>

<details>
<summary>
This succeeds:

    $ brew install banh-canh/ytui/ytui

</summary>

```
==> Fetching banh-canh/ytui/ytui
==> Downloading https://github.com/Banh-Canh/ytui/releases/down
==> Downloading from https://objects.githubusercontent.com/gith
######################################################## 100.0%
==> Installing ytui from banh-canh/ytui
🍺  /home/linuxbrew/.linuxbrew/Cellar/ytui/0.2.1: 6 files, 10.2MB, built in 2 seconds
==> Running `brew cleanup ytui`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

</details>


This was all tested on a clean install of Fedora 40 with a fresh install of homebrew.

I am guessing that brew works the exact same on macOS.

----

See also: [homebrew-ytui Issue #1](https://github.com/Banh-Canh/homebrew-ytui/issues/1)